### PR TITLE
Fix a typo in `docs/debugging.rst`

### DIFF
--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -4,7 +4,7 @@ Test remote access of an image locally
 If you are on Linux, you may use a script provided ``./scripts/test_noVNC_directly.sh``
 directly in your terminal::
 
-  $ ./scripts/test_noVNC_directly.sh image_name ./scripts/test_env_file test
+  $ ./scripts/test_novnc_directly.sh image_name ./scripts/test_env_file test
 
 On Mac OS X, you should run the above script in your docker VM.
 You should clean up the started container once you finish testing.


### PR DESCRIPTION
Fix a typo in `docs/debugging.rst`